### PR TITLE
Feature/12

### DIFF
--- a/src/psr4/.build.xml
+++ b/src/psr4/.build.xml
@@ -707,7 +707,8 @@
           </fileset>
           <filterchain>
             <replaceregexp>
-              <regexp pattern="\/\*\!?\[pro strip\-from\=['&quot;]lite['&quot;]\]\*\/(?:.*?)\/\*\!?\[\/pro\]\*\/" replace="" modifiers="s" />
+              <regexp pattern="\/\*\!\[pro strip\-from\=['&quot;]lite['&quot;]\]\*\/(?:.*?)\/\*\!\[\/pro\]\*\/" replace="" modifiers="s" />
+              <regexp pattern="\/\*\[pro strip\-from\=['&quot;]lite['&quot;]\]\*\/(?:.*?)\/\*\[\/pro\]\*\/" replace="" modifiers="s" />
             </replaceregexp>
           </filterchain>
         </reflexive>

--- a/src/psr4/.build.xml
+++ b/src/psr4/.build.xml
@@ -707,7 +707,7 @@
           </fileset>
           <filterchain>
             <replaceregexp>
-              <regexp pattern="\/\*\[pro strip\-from\=['&quot;]lite['&quot;]\]\*\/(?:.*?)\/\*\[\/pro\]\*\/" replace="" modifiers="s" />
+              <regexp pattern="\/\*\!?\[pro strip\-from\=['&quot;]lite['&quot;]\]\*\/(?:.*?)\/\*\!?\[\/pro\]\*\/" replace="" modifiers="s" />
             </replaceregexp>
           </filterchain>
         </reflexive>


### PR DESCRIPTION
Adding support for this alternate variation.

```
/*![pro strip-from='lite']*/
/*![/pro]*/
```

JS/CSS compressors will preserve comments like this, which is desirable whenever the pro copy contains JS/CSS files compiled into compressed versions. This also resolves websharks/phings#12
