### PR TITLE
Exclude bourbon, .scss, and .map files from distribution ZIP/TGZ/PHAR

### DIFF
--- a/src/psr4/targets/config.xml
+++ b/src/psr4/targets/config.xml
@@ -37,6 +37,15 @@
         <exclude name="vendor/bin/**" />
         <exclude name="**/vendor/bin/**" />
 
+        <exclude name="vendor/**.scss" />
+        <exclude name="**/vendor/**.scss" />
+
+        <exclude name="vendor/**.css.map" />
+        <exclude name="**/vendor/**.css.map" />
+
+        <exclude name="vendor/package/bourbon/**" />
+        <exclude name="**/vendor/package/bourbon/**" />
+
         <exclude name=".ht**" />
         <exclude name="**/.ht**" />
 
@@ -127,6 +136,15 @@
 
         <exclude name="vendor/bin/**" />
         <exclude name="**/vendor/bin/**" />
+
+        <exclude name="vendor/**.scss" />
+        <exclude name="**/vendor/**.scss" />
+
+        <exclude name="vendor/**.css.map" />
+        <exclude name="**/vendor/**.css.map" />
+
+        <exclude name="vendor/package/bourbon/**" />
+        <exclude name="**/vendor/package/bourbon/**" />
 
         <exclude name=".ht**" />
         <exclude name="**/.ht**" />


### PR DESCRIPTION
See websharks/zencache#579
