### PR TITLE
Several Enhancements & Bug Fixes

### DIFF
--- a/src/psr4/example.props
+++ b/src/psr4/example.props
@@ -25,5 +25,9 @@ project_version                                         = %y%m%d
 project_php_required_version                            = 5.4.7
 project_php_tested_up_to_version                        = ${php.version}
 
-project_wp_required_version                             = 4.2.2
-project_wp_tested_up_to_version                         = 4.2.2
+project_wp_required_version                             = 4.4
+project_wp_tested_up_to_version                         = 4.5-alpha
+
+project_wp_sharks_core_required_version                 = 160229
+project_wp_sharks_core_tested_up_to_version             = 160229
+project_wp_sharks_core_max_compatible_version           =

--- a/src/psr4/targets.xml
+++ b/src/psr4/targets.xml
@@ -24,12 +24,16 @@
     <!-- Default/visible build targets. -->
     <!-- ============================================  -->
 
-    <target name="build" depends="-config,-validate,-preamble,-prepare,-rtokens,-composer,-rebrand,-pots,-packages,-distros,-lite">
+    <target name="build" depends="-config,-validate,-preamble,-prepare,-composer-lock-preserve,-rebrand,-packages,-distros,-lite">
       <echo msg="Build complete! :-)" />
     </target>
 
+    <target name="build-all" depends="-config,-validate,-preamble,-prepare,-rtokens,-composer,-rebrand,-pots,-packages,-distros,-lite">
+      <echo msg="Full build complete! :-)" />
+    </target>
+
     <target name="post-receive-build" depends="-config,-validate,-preamble,-prepare,-composer-lock-preserve,-composer,-rebrand">
-      <echo msg="Build complete! :-)" />
+      <echo msg="Post receive build complete! :-)" />
     </target>
 
     <target name="codex" depends="-config,-validate,-preamble,-apigen">

--- a/src/psr4/targets/config.xml
+++ b/src/psr4/targets/config.xml
@@ -204,10 +204,10 @@
           <isset property="project_slug" />
         </and>
         <then>
-          <php expression="preg_replace('/\-(?:lite|pro)$/ui', '', '${project_slug}')" returnproperty="project-text-domain" />
+          <php expression="preg_replace('/\-(?:lite|pro)$/ui', '', '${project_slug}')" returnproperty="_project_text_domain" />
         </then>
         <else>
-          <property name="project-text-domain" value="" />
+          <property name="_project_text_domain" value="" />
         </else>
       </if>
 

--- a/src/psr4/targets/config.xml
+++ b/src/psr4/targets/config.xml
@@ -197,6 +197,20 @@
       <tstamp><format property="_time_ymd" pattern="%y%m%d" /></tstamp>
       <php expression="str_replace('%y%m%d', date('ymd'), '${project_version}')" returnproperty="project_version" />
 
+      <!-- Properties derived from other properties. -->
+
+      <if>
+        <and>
+          <isset property="project_slug" />
+        </and>
+        <then>
+          <php expression="preg_replace('/\-(?:lite|pro)$/ui', '', '${project_slug}')" returnproperty="project-text-domain" />
+        </then>
+        <else>
+          <property name="project-text-domain" value="" />
+        </else>
+      </if>
+
       <!-- WordPress theme/plugin detection. -->
 
       <if>
@@ -212,6 +226,25 @@
         </else>
       </if>
 
+      <!-- WordPress WP Sharks Core theme/plugin detection. -->
+
+      <if>
+        <and>
+          <istrue value="${_is_wp_theme_plugin}" />
+          <or>
+            <isset property="project_wp_sharks_core_required_version" />
+            <isset property="project_wp_sharks_core_tested_up_to_version" />
+            <isset property="project_wp_sharks_core_max_compatible_version" />
+          </or>
+        </and>
+        <then>
+          <property name="_is_wp_sharks_core_theme_plugin" value="true" />
+        </then>
+        <else>
+          <property name="_is_wp_sharks_core_theme_plugin" value="false" />
+        </else>
+      </if>
+
       <!-- Lite detection; i.e., is applicable? -->
 
       <if>
@@ -221,6 +254,12 @@
 
           <isset property="project_lite_namespace" />
           <isset property="project_lite_sub_namespace" />
+
+          <isset property="project_lite_other_phar_fileset_exclusions" />
+          <isset property="project_lite_other_zip_tgz_fileset_exclusions" />
+
+          <isset property="project_lite_text_domain_regex_replacement_pattern" />
+          <isset property="project_lite_alter_namespace_in_other_files_pattern" />
         </or>
         <then>
           <property name="_is_lite_applicable" value="true" />

--- a/src/psr4/targets/config.xml
+++ b/src/psr4/targets/config.xml
@@ -12,6 +12,168 @@
 
       <property file="${project.basedir}/.build.props" />
 
+      <!-- WordPress theme/plugin detection. -->
+
+      <if>
+        <or>
+          <isset property="project_wp_required_version" />
+          <isset property="project_wp_tested_up_to_version" />
+        </or>
+        <then>
+          <property name="_is_wp_theme_plugin" value="true" />
+        </then>
+        <else>
+          <property name="_is_wp_theme_plugin" value="false" />
+        </else>
+      </if>
+
+      <!-- WordPress WP Sharks Core theme/plugin detection. -->
+
+      <if>
+        <and>
+          <istrue value="${_is_wp_theme_plugin}" />
+          <or>
+            <isset property="project_wp_sharks_core_required_version" />
+            <isset property="project_wp_sharks_core_tested_up_to_version" />
+            <isset property="project_wp_sharks_core_max_compatible_version" />
+          </or>
+        </and>
+        <then>
+          <property name="_is_wp_sharks_core_theme_plugin" value="true" />
+        </then>
+        <else>
+          <property name="_is_wp_sharks_core_theme_plugin" value="false" />
+        </else>
+      </if>
+
+      <!-- Lite detection; i.e., is applicable? -->
+
+      <if>
+        <and>
+          <not>
+            <isset property="is_lite_build" />
+          </not>
+          <or>
+            <isset property="project_lite_title" />
+            <isset property="project_lite_slug" />
+
+            <isset property="project_lite_namespace" />
+            <isset property="project_lite_sub_namespace" />
+
+            <isset property="project_lite_other_phar_fileset_exclusions" />
+            <isset property="project_lite_other_zip_tgz_fileset_exclusions" />
+
+            <isset property="project_lite_text_domain_regex_replacement_pattern" />
+            <isset property="project_lite_alter_namespace_in_other_files_pattern" />
+          </or>
+        </and>
+        <then>
+          <property name="_has_lite_build_props" value="true" />
+        </then>
+        <else>
+          <property name="_has_lite_build_props" value="false" />
+        </else>
+      </if>
+
+      <!-- Make sure optional properties are defined. -->
+
+      <if>
+        <not>
+          <isset property="project_other_phar_fileset_exclusions" />
+        </not>
+        <then>
+          <property name="project_other_phar_fileset_exclusions" value="" />
+        </then>
+      </if>
+      <if>
+        <not>
+          <isset property="project_other_zip_tgz_fileset_exclusions" />
+        </not>
+        <then>
+          <property name="project_other_zip_tgz_fileset_exclusions" value="" />
+        </then>
+      </if>
+
+      <if>
+        <and>
+          <not>
+            <isset property="is_lite_build" />
+          </not>
+          <istrue value="${_has_lite_build_props}" />
+        </and>
+        <then>
+          <if>
+            <not>
+              <isset property="project_lite_other_phar_fileset_exclusions" />
+            </not>
+            <then>
+              <property name="project_lite_other_phar_fileset_exclusions" value="" />
+            </then>
+          </if>
+          <if>
+            <not>
+              <isset property="project_lite_other_zip_tgz_fileset_exclusions" />
+            </not>
+            <then>
+              <property name="project_lite_other_zip_tgz_fileset_exclusions" value="" />
+            </then>
+          </if>
+          <if>
+            <not>
+              <isset property="project_lite_text_domain_regex_replacement_pattern" />
+            </not>
+            <then>
+              <property name="project_lite_text_domain_regex_replacement_pattern" value="" />
+            </then>
+          </if>
+          <if>
+            <not>
+              <isset property="project_lite_alter_namespace_in_other_files_pattern" />
+            </not>
+            <then>
+              <property name="project_lite_alter_namespace_in_other_files_pattern" value="" />
+            </then>
+          </if>
+        </then>
+      </if>
+
+      <if>
+        <and>
+          <istrue value="${_is_wp_theme_plugin}" />
+          <istrue value="${_is_wp_sharks_core_theme_plugin}" />
+        </and>
+        <then>
+          <if>
+            <not>
+              <isset property="project_wp_sharks_core_max_compatible_version" />
+            </not>
+            <then>
+              <property name="project_wp_sharks_core_max_compatible_version" value="" />
+            </then>
+          </if>
+        </then>
+      </if>
+
+      <!-- Properties derived from other properties. -->
+
+      <if>
+        <and>
+          <isset property="project_slug" />
+        </and>
+        <then>
+          <php expression="preg_replace('/\-(?:lite|pro)$/ui', '', '${project_slug}')" returnproperty="_project_text_domain" />
+        </then>
+        <else>
+          <property name="_project_text_domain" value="" />
+        </else>
+      </if>
+
+      <tstamp><format property="_time_ymd" pattern="%y%m%d" /></tstamp>
+
+      <!-- Property replacement codes. -->
+
+      <php expression="str_replace('%y%m%d', date('ymd'), '${project_version}')" returnproperty="project_version" />
+
       <!-- Codex ignore list. -->
 
       <property name="_codex_ignore" value="*/assets/*,*/phings/*,*/tests/*,*/vendor/*" />
@@ -191,83 +353,6 @@
         <exclude name="composer.lock" />
         <exclude name="**/composer.lock" />
       </fileset>
-
-      <!-- Property replacement codes. -->
-
-      <tstamp><format property="_time_ymd" pattern="%y%m%d" /></tstamp>
-      <php expression="str_replace('%y%m%d', date('ymd'), '${project_version}')" returnproperty="project_version" />
-
-      <!-- Properties derived from other properties. -->
-
-      <if>
-        <and>
-          <isset property="project_slug" />
-        </and>
-        <then>
-          <php expression="preg_replace('/\-(?:lite|pro)$/ui', '', '${project_slug}')" returnproperty="_project_text_domain" />
-        </then>
-        <else>
-          <property name="_project_text_domain" value="" />
-        </else>
-      </if>
-
-      <!-- WordPress theme/plugin detection. -->
-
-      <if>
-        <or>
-          <isset property="project_wp_required_version" />
-          <isset property="project_wp_tested_up_to_version" />
-        </or>
-        <then>
-          <property name="_is_wp_theme_plugin" value="true" />
-        </then>
-        <else>
-          <property name="_is_wp_theme_plugin" value="false" />
-        </else>
-      </if>
-
-      <!-- WordPress WP Sharks Core theme/plugin detection. -->
-
-      <if>
-        <and>
-          <istrue value="${_is_wp_theme_plugin}" />
-          <or>
-            <isset property="project_wp_sharks_core_required_version" />
-            <isset property="project_wp_sharks_core_tested_up_to_version" />
-            <isset property="project_wp_sharks_core_max_compatible_version" />
-          </or>
-        </and>
-        <then>
-          <property name="_is_wp_sharks_core_theme_plugin" value="true" />
-        </then>
-        <else>
-          <property name="_is_wp_sharks_core_theme_plugin" value="false" />
-        </else>
-      </if>
-
-      <!-- Lite detection; i.e., is applicable? -->
-
-      <if>
-        <or>
-          <isset property="project_lite_title" />
-          <isset property="project_lite_slug" />
-
-          <isset property="project_lite_namespace" />
-          <isset property="project_lite_sub_namespace" />
-
-          <isset property="project_lite_other_phar_fileset_exclusions" />
-          <isset property="project_lite_other_zip_tgz_fileset_exclusions" />
-
-          <isset property="project_lite_text_domain_regex_replacement_pattern" />
-          <isset property="project_lite_alter_namespace_in_other_files_pattern" />
-        </or>
-        <then>
-          <property name="_is_lite_applicable" value="true" />
-        </then>
-        <else>
-          <property name="_is_lite_applicable" value="false" />
-        </else>
-      </if>
 
     </target>
 

--- a/src/psr4/targets/lite.xml
+++ b/src/psr4/targets/lite.xml
@@ -11,9 +11,9 @@
       <if>
         <and>
           <not>
-            <isset property="is_lite" />
+            <isset property="is_lite_build" />
           </not>
-          <istrue value="${_is_lite_applicable}" />
+          <istrue value="${_has_lite_build_props}" />
         </and>
         <then>
           <!-- Prepare for lite generation. -->
@@ -267,7 +267,7 @@
           <echo msg="Building lite variation from: ${project.basedir}/.~build/${project_lite_slug}/build.xml" />
 
           <phing phingfile="${project.basedir}/.~build/${project_lite_slug}/build.xml" inheritall="false" inheritrefs="false" haltonfailure="true">
-            <property name="is_lite" value="true" />
+            <property name="is_lite_build" value="true" />
           </phing>
 
         </then>

--- a/src/psr4/targets/lite.xml
+++ b/src/psr4/targets/lite.xml
@@ -215,7 +215,7 @@
                 </fileset>
                 <filterchain>
                   <replaceregexp>
-                    <regexp pattern="(,\s*)(${project_lite_text_domain_regex_replacement_pattern})(\s*\))" replace="$1'${project-text-domain}'$3" modifiers="u" />
+                    <regexp pattern="(,\s*)(${project_lite_text_domain_regex_replacement_pattern})(\s*\))" replace="$1'${_project_text_domain}'$3" modifiers="u" />
                   </replaceregexp>
                 </filterchain>
               </reflexive>

--- a/src/psr4/targets/lite.xml
+++ b/src/psr4/targets/lite.xml
@@ -201,6 +201,7 @@
           <if>
             <and>
               <istrue value="${_is_wp_theme_plugin}" />
+              <istrue value="${project_lite_text_domain_regex_replacement_pattern}" />
             </and>
             <then>
               <echo msg="Converting text-domain references to string literals in: ${project.basedir}/.~build/${project_lite_slug}" />
@@ -214,7 +215,7 @@
                 </fileset>
                 <filterchain>
                   <replaceregexp>
-                    <regexp pattern="(,\s*)(${project_lite_text_domain_regex_replacement_pattern})(\s*\))" replace="$1'${project_lite_slug}'$3" modifiers="u" />
+                    <regexp pattern="(,\s*)(${project_lite_text_domain_regex_replacement_pattern})(\s*\))" replace="$1'${project-text-domain}'$3" modifiers="u" />
                   </replaceregexp>
                 </filterchain>
               </reflexive>
@@ -228,7 +229,7 @@
             </else>
           </if>
 
-          <!-- Modify build properties. -->
+          <!-- Modify build properties; i.e., swap w/ lite property values. -->
 
           <echo msg="Modifying lite build properties: ${project.basedir}/.~build/${project_lite_slug}/.build.props" />
 

--- a/src/psr4/targets/pots.xml
+++ b/src/psr4/targets/pots.xml
@@ -16,6 +16,28 @@
         </and>
         <then>
 
+          <!-- Force  `__()` and other i18n calls w/ no text domain to contain a text-domain. -->
+
+          <echo msg="Forcing `__()` and other i18n calls w/ no text domain to contain a text-domain in: ${project.basedir}" />
+
+          <reflexive>
+            <fileset dir="${project.basedir}" casesensitive="false">
+              <exclude pattern="src/vendor/**" />
+              <include pattern="*.php" />
+              <include pattern="**/**.php" />
+            </fileset>
+            <filterchain>
+              <replaceregexp>
+                <regexp pattern="\b__\s*\(\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="__('$1', '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b_x\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_x('$1', '$2', '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b_n\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*\)" replace="_n('$1', '$2', $3, '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b_nx\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_nx('$1', '$2', $3, '$4', '${project-text-domain}')" modifiers="u" />
+              </replaceregexp>
+            </filterchain>
+          </reflexive>
+
+          <echo msg="------------------------------------" />
+
           <!-- WordPress theme. -->
 
           <if>

--- a/src/psr4/targets/pots.xml
+++ b/src/psr4/targets/pots.xml
@@ -28,10 +28,10 @@
             </fileset>
             <filterchain>
               <replaceregexp>
-                <regexp pattern="\b__\s*\(\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="__('$1', '${project-text-domain}')" modifiers="u" />
-                <regexp pattern="\b_x\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_x('$1', '$2', '${project-text-domain}')" modifiers="u" />
-                <regexp pattern="\b_n\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*\)" replace="_n('$1', '$2', $3, '${project-text-domain}')" modifiers="u" />
-                <regexp pattern="\b_nx\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_nx('$1', '$2', $3, '$4', '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b__\s*\(\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="__('$1', '${_project_text_domain}')" modifiers="u" />
+                <regexp pattern="\b_x\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_x('$1', '$2', '${_project_text_domain}')" modifiers="u" />
+                <regexp pattern="\b_n\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*\)" replace="_n('$1', '$2', $3, '${_project_text_domain}')" modifiers="u" />
+                <regexp pattern="\b_nx\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_nx('$1', '$2', $3, '$4', '${_project_text_domain}')" modifiers="u" />
               </replaceregexp>
             </filterchain>
           </reflexive>

--- a/src/psr4/targets/pots.xml
+++ b/src/psr4/targets/pots.xml
@@ -47,6 +47,8 @@
             <then>
               <echo msg="Building POT translation file for WP theme: ${project.basedir}" />
 
+              <mkdir dir="${project.basedir}/src/includes/translations" />
+
               <exec executable="${project.basedir}/src/vendor/websharks/wp-i18n-tools/makepot.php" dir="${project.basedir}" passthru="true" checkreturn="true">
                 <arg value="wp-theme" />
                 <arg value="${project.basedir}" />
@@ -70,6 +72,8 @@
             </and>
             <then>
               <echo msg="Building POT translation file for WP plugin: ${project.basedir}" />
+
+              <mkdir dir="${project.basedir}/src/includes/translations" />
 
               <exec executable="${project.basedir}/src/vendor/websharks/wp-i18n-tools/makepot.php" dir="${project.basedir}" passthru="true" checkreturn="true">
                 <arg value="wp-plugin" />

--- a/src/psr4/targets/preamble.xml
+++ b/src/psr4/targets/preamble.xml
@@ -29,7 +29,7 @@
 
       <echo msg="Project Org.: ${project_owner}" />
       <echo msg="Project Slug: ${project_slug}" />
-      <echo msg="Project Text Domain: ${project-text-domain}" />
+      <echo msg="Project Text Domain: ${_project_text_domain}" />
 
       <echo msg="------------------------------------" />
 

--- a/src/psr4/targets/preamble.xml
+++ b/src/psr4/targets/preamble.xml
@@ -87,6 +87,19 @@
           <echo msg="Project WP Tested Up To Version: ${project_wp_tested_up_to_version}" />
 
           <echo msg="------------------------------------" />
+
+          <if>
+            <and>
+              <istrue value="${_is_wp_sharks_core_theme_plugin}" />
+            </and>
+            <then>
+              <echo msg="Project WP Sharks Core Required Version: ${project_wp_sharks_core_required_version}" />
+              <echo msg="Project WP Sharks Core Tested Up To Version: ${project_wp_sharks_core_tested_up_to_version}" />
+              <echo msg="Project WP Sharks Core Max Compatible Version: ${project_wp_sharks_core_max_compatible_version}" />
+
+              <echo msg="------------------------------------" />
+            </then>
+          </if>
         </then>
       </if>
 

--- a/src/psr4/targets/preamble.xml
+++ b/src/psr4/targets/preamble.xml
@@ -46,9 +46,9 @@
       <if>
         <and>
           <not>
-            <isset property="is_lite" />
+            <isset property="is_lite_build" />
           </not>
-          <istrue value="${_is_lite_applicable}" />
+          <istrue value="${_has_lite_build_props}" />
         </and>
         <then>
           <echo msg="Project Lite Title: ${project_lite_title}" />

--- a/src/psr4/targets/preamble.xml
+++ b/src/psr4/targets/preamble.xml
@@ -29,18 +29,17 @@
 
       <echo msg="Project Org.: ${project_owner}" />
       <echo msg="Project Slug: ${project_slug}" />
+      <echo msg="Project Text Domain: ${project-text-domain}" />
 
       <echo msg="------------------------------------" />
 
-      <echo msg="Project NS: ${project_namespace}" />
-      <echo msg="Project SNS: ${project_sub_namespace}" />
+      <echo msg="Project Namespace: ${project_namespace}" />
+      <echo msg="Project Sub-Namespace: ${project_sub_namespace}" />
 
       <echo msg="------------------------------------" />
 
       <echo msg="Project-Specific PHAR Exclusions: ${project_other_phar_fileset_exclusions}" />
       <echo msg="Project-Specific ZIP/TGZ Exclusions: ${project_other_zip_tgz_fileset_exclusions}" />
-      <echo msg="Project-Specific Text Domain Replacement Pattern: ${project_lite_text_domain_regex_replacement_pattern}" />
-      <echo msg="Project-Specific Namespace Altered in Other Files: ${project_lite_alter_namespace_in_other_files_pattern}" />
 
       <echo msg="------------------------------------" />
 
@@ -57,13 +56,18 @@
 
           <echo msg="------------------------------------" />
 
-          <echo msg="Project Lite NS: ${project_lite_namespace}" />
-          <echo msg="Project Lite SNS: ${project_lite_sub_namespace}" />
+          <echo msg="Project Lite Namespace: ${project_lite_namespace}" />
+          <echo msg="Project Lite Sub-Namespace: ${project_lite_sub_namespace}" />
 
           <echo msg="------------------------------------" />
 
           <echo msg="Lite Project-Specific PHAR Exclusions: ${project_lite_other_phar_fileset_exclusions}" />
           <echo msg="Lite Project-Specific ZIP/TGZ Exclusions: ${project_lite_other_zip_tgz_fileset_exclusions}" />
+
+          <echo msg="------------------------------------" />
+
+          <echo msg="Lite Project-Specific Text Domain Replacement Pattern: ${project_lite_text_domain_regex_replacement_pattern}" />
+          <echo msg="Lite Project-Specific Namespace Altered in Other Files: ${project_lite_alter_namespace_in_other_files_pattern}" />
 
           <echo msg="------------------------------------" />
         </then>

--- a/src/psr4/targets/push-lite.xml
+++ b/src/psr4/targets/push-lite.xml
@@ -11,9 +11,9 @@
       <if>
         <and>
           <not>
-            <isset property="is_lite" />
+            <isset property="is_lite_build" />
           </not>
-          <istrue value="${_is_lite_applicable}" />
+          <istrue value="${_has_lite_build_props}" />
         </and>
         <then>
           <!-- Define lite repo directory and remote. -->

--- a/src/psr4/targets/rebrand.xml
+++ b/src/psr4/targets/rebrand.xml
@@ -45,35 +45,26 @@
 
           <echo msg="------------------------------------" />
 
-          <!-- WordPress text-domain string literal. -->
+          <!-- Text-domain rebranding. -->
 
-          <if>
-            <and>
-              <istrue value="${_is_wp_theme_plugin}" />
-            </and>
-            <then>
-              <echo msg="Adding WP text-domain string literal in: ${project.basedir}/src/vendor/websharks/core" />
+          <echo msg="Rebranding text-domain in: ${project.basedir}/src/vendor/websharks/core" />
 
-              <reflexive>
-                <fileset dir="${project.basedir}/src/vendor/websharks/core" casesensitive="false">
-                  <include pattern="*.php" />
-                  <include pattern="**/**.php" />
-                </fileset>
-                <filterchain>
-                  <replaceregexp>
-                    <regexp pattern="\b__\('(.*?[^\\])'\)" replace="__('$1', '${project_slug}');" modifiers="u" />
-                  </replaceregexp>
-                </filterchain>
-              </reflexive>
+          <reflexive>
+            <fileset dir="${project.basedir}/src/vendor/websharks/core" casesensitive="false">
+              <include pattern="*.php" />
+              <include pattern="**/**.php" />
+            </fileset>
+            <filterchain>
+              <replaceregexp>
+                <regexp pattern="\b__\s*\(\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="__('$1', '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b_x\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_x('$1', '$2', '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b_n\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*\)" replace="_n('$1', '$2', $3, '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b_nx\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_nx('$1', '$2', $3, '$4', '${project-text-domain}')" modifiers="u" />
+              </replaceregexp>
+            </filterchain>
+          </reflexive>
 
-              <echo msg="------------------------------------" />
-            </then>
-            <else>
-              <echo msg="N/A: skipping WP text-domain as string literal while rebranding the websharks/core." />
-
-              <echo msg="------------------------------------" />
-            </else>
-          </if>
+          <echo msg="------------------------------------" />
 
         </then>
         <else>

--- a/src/psr4/targets/rebrand.xml
+++ b/src/psr4/targets/rebrand.xml
@@ -56,10 +56,10 @@
             </fileset>
             <filterchain>
               <replaceregexp>
-                <regexp pattern="\b__\s*\(\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="__('$1', '${project-text-domain}')" modifiers="u" />
-                <regexp pattern="\b_x\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_x('$1', '$2', '${project-text-domain}')" modifiers="u" />
-                <regexp pattern="\b_n\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*\)" replace="_n('$1', '$2', $3, '${project-text-domain}')" modifiers="u" />
-                <regexp pattern="\b_nx\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_nx('$1', '$2', $3, '$4', '${project-text-domain}')" modifiers="u" />
+                <regexp pattern="\b__\s*\(\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="__('$1', '${_project_text_domain}')" modifiers="u" />
+                <regexp pattern="\b_x\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_x('$1', '$2', '${_project_text_domain}')" modifiers="u" />
+                <regexp pattern="\b_n\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*\)" replace="_n('$1', '$2', $3, '${_project_text_domain}')" modifiers="u" />
+                <regexp pattern="\b_nx\s*\(\s*'((?:\\.|[^\\'])+?)'\s*,\s*'((?:\\.|[^\\'])+?)'\s*,\s*([^(),]+)\s*,\s*'((?:\\.|[^\\'])+?)'\s*\)" replace="_nx('$1', '$2', $3, '$4', '${_project_text_domain}')" modifiers="u" />
               </replaceregexp>
             </filterchain>
           </reflexive>

--- a/src/psr4/targets/rtokens.xml
+++ b/src/psr4/targets/rtokens.xml
@@ -22,11 +22,11 @@
         </fileset>
         <filterchain>
           <replaceregexp>
+            <regexp pattern="'[^']*?';\s*\/\/v\/\/$" replace="'${project_version}'; //v//" modifiers="um" />
+            <regexp pattern='"[^"]*?";\s*\/\/v\/\/$' replace='"${project_version}"; //v//' modifiers="um" />
+
             <regexp pattern="'[^']*?';\s*\/\/version\/\/$" replace="'${project_version}'; //version//" modifiers="um" />
             <regexp pattern='"[^"]*?";\s*\/\/version\/\/$' replace='"${project_version}"; //version//' modifiers="um" />
-
-            <regexp pattern="^(\s*)const\s+VERSION\s*=\s*'[^']*?';\s*\/\/v\/\/$" replace="\1const VERSION = '${project_version}'; //v//" modifiers="um" />
-            <regexp pattern='^(\s*)const\s+VERSION\s*=\s*"[^"]*?";\s*\/\/v\/\/$' replace='\1const VERSION = "${project_version}"; //v//' modifiers="um" />
 
             <regexp pattern="'[^']*?';\s*\/\/php\-required\-version\/\/$" replace="'${project_php_required_version}'; //php-required-version//" modifiers="um" />
             <regexp pattern='"[^"]*?";\s*\/\/php\-required\-version\/\/$' replace='"${project_php_required_version}"; //php-required-version//' modifiers="um" />
@@ -59,14 +59,24 @@
             </fileset>
             <filterchain>
               <replaceregexp>
-                <regexp pattern="^Version\:.+$" replace="Version: ${project_version}" modifiers="um" />
-                <regexp pattern="^Stable tag\:.+$" replace="Stable tag: ${project_version}" modifiers="um" />
+                <regexp pattern="^(\s*\*\s*)?Version\:.+$" replace="$1Version: ${project_version}" modifiers="um" />
+                <regexp pattern="^(\s*\*\s*)?Stable tag\:.+$" replace="$1Stable tag: ${project_version}" modifiers="um" />
 
-                <regexp pattern="^Requires at least\:.+$" replace="Requires at least: ${project_wp_required_version}" modifiers="um" />
-                <regexp pattern="^Tested up to\:.+$" replace="Tested up to: ${project_wp_tested_up_to_version}" modifiers="um" />
+                <regexp pattern="^(\s*\*\s*)?Requires at least\:.+$" replace="$1Requires at least: ${project_wp_required_version}" modifiers="um" />
+                <regexp pattern="^(\s*\*\s*)?Tested up to\:.+$" replace="$1Tested up to: ${project_wp_tested_up_to_version}" modifiers="um" />
 
-                <regexp pattern="^Requires PHP\:.+$" replace="Requires PHP: ${project_php_required_version}" modifiers="um" />
-                <regexp pattern="^Tested up to PHP\:.+$" replace="Tested up to PHP: ${project_php_tested_up_to_version}" modifiers="um" />
+                <regexp pattern="^(\s*\*\s*)?Requires PHP\:.+$" replace="$1Requires PHP: ${project_php_required_version}" modifiers="um" />
+                <regexp pattern="^(\s*\*\s*)?Tested up to PHP\:.+$" replace="$1Tested up to PHP: ${project_php_tested_up_to_version}" modifiers="um" />
+                <if>
+                  <and>
+                    <istrue value="${_is_wp_sharks_core_theme_plugin}" />
+                  </and>
+                  <then>
+                    <regexp pattern="^(\s*\*\s*)?Requires WP Sharks Core\:.+$" replace="$1Requires WP Sharks Core: ${project_wp_sharks_core_required_version}" modifiers="um" />
+                    <regexp pattern="^(\s*\*\s*)?Tested up to WP Sharks Core\:.+$" replace="$1Tested up to WP Sharks Core: ${project_wp_sharks_core_tested_up_to_version}" modifiers="um" />
+                    <regexp pattern="^(\s*\*\s*)?Max compatible WP Sharks Core\:.+$" replace="$1Max compatible WP Sharks Core: ${project_wp_sharks_core_max_compatible_version}" modifiers="um" />
+                  </then>
+                </if>
               </replaceregexp>
             </filterchain>
           </reflexive>
@@ -104,6 +114,21 @@
 
                 <regexp pattern="'[^']*?';\s*\/\/wp\-up\-to\-version\/\/$" replace="'${project_wp_tested_up_to_version}'; //wp-up-to-version//" modifiers="um" />
                 <regexp pattern='"[^"]*?";\s*\/\/wp\-up\-to\-version\/\/$' replace='"${project_wp_tested_up_to_version}"; //wp-up-to-version//' modifiers="um" />
+                <if>
+                  <and>
+                    <istrue value="${_is_wp_sharks_core_theme_plugin}" />
+                  </and>
+                  <then>
+                    <regexp pattern="'[^']*?';\s*\/\/wp\-sharks\-core\-required\-version\/\/$" replace="'${project_wp_sharks_core_required_version}'; //wp-sharks-core-required-version//" modifiers="um" />
+                    <regexp pattern='"[^"]*?";\s*\/\/wp\-sharks\-core\-required\-version\/\/$' replace='"${project_wp_sharks_core_required_version}"; //wp-sharks-core-required-version//' modifiers="um" />
+
+                    <regexp pattern="'[^']*?';\s*\/\/wp\-sharks\-core\-up\-to\-version\/\/$" replace="'${project_wp_sharks_core_tested_up_to_version}'; //wp-sharks-core-up-to-version//" modifiers="um" />
+                    <regexp pattern='"[^"]*?";\s*\/\/wp\-sharks\-core\-up\-to\-version\/\/$' replace='"${project_wp_sharks_core_tested_up_to_version}"; //wp-sharks-core-up-to-version//' modifiers="um" />
+
+                    <regexp pattern="'[^']*?';\s*\/\/wp\-sharks\-core\-max\-compatible\-version\/\/$" replace="'${project_wp_sharks_core_max_compatible_version}'; //wp-sharks-core-max-compatible-version//" modifiers="um" />
+                    <regexp pattern='"[^"]*?";\s*\/\/wp\-sharks\-core\-max\-compatible\-version\/\/$' replace='"${project_wp_sharks_core_max_compatible_version}"; //wp-sharks-core-max-compatible-version//' modifiers="um" />
+                  </then>
+                </if>
               </replaceregexp>
             </filterchain>
           </reflexive>

--- a/src/psr4/targets/rtokens.xml
+++ b/src/psr4/targets/rtokens.xml
@@ -67,24 +67,39 @@
 
                 <regexp pattern="^(\s*\*\s*)?Requires PHP\:.+$" replace="$1Requires PHP: ${project_php_required_version}" modifiers="um" />
                 <regexp pattern="^(\s*\*\s*)?Tested up to PHP\:.+$" replace="$1Tested up to PHP: ${project_php_tested_up_to_version}" modifiers="um" />
-                <if>
-                  <and>
-                    <istrue value="${_is_wp_sharks_core_theme_plugin}" />
-                  </and>
-                  <then>
-                    <regexp pattern="^(\s*\*\s*)?Requires WP Sharks Core\:.+$" replace="$1Requires WP Sharks Core: ${project_wp_sharks_core_required_version}" modifiers="um" />
-                    <regexp pattern="^(\s*\*\s*)?Tested up to WP Sharks Core\:.+$" replace="$1Tested up to WP Sharks Core: ${project_wp_sharks_core_tested_up_to_version}" modifiers="um" />
-                    <regexp pattern="^(\s*\*\s*)?Max compatible WP Sharks Core\:.+$" replace="$1Max compatible WP Sharks Core: ${project_wp_sharks_core_max_compatible_version}" modifiers="um" />
-                  </then>
-                </if>
               </replaceregexp>
             </filterchain>
           </reflexive>
 
+          <if>
+            <and>
+              <istrue value="${_is_wp_sharks_core_theme_plugin}" />
+            </and>
+            <then>
+              <reflexive>
+                <fileset dir="${project.basedir}" casesensitive="false">
+                  <include pattern="readme.txt" />
+                  <include pattern="plugin.php" />
+                  <include pattern="${project_slug}.php" />
+                  <include pattern="uninstall.php" />
+                  <include pattern="functions.php" />
+                  <include pattern="style.css" />
+                </fileset>
+                <filterchain>
+                  <replaceregexp>
+                    <regexp pattern="^(\s*\*\s*)?Requires WP Sharks Core\:.+$" replace="$1Requires WP Sharks Core: ${project_wp_sharks_core_required_version}" modifiers="um" />
+                    <regexp pattern="^(\s*\*\s*)?Tested up to WP Sharks Core\:.+$" replace="$1Tested up to WP Sharks Core: ${project_wp_sharks_core_tested_up_to_version}" modifiers="um" />
+                    <regexp pattern="^(\s*\*\s*)?Max compatible WP Sharks Core\:.+$" replace="$1Max compatible WP Sharks Core: ${project_wp_sharks_core_max_compatible_version}" modifiers="um" />
+                  </replaceregexp>
+                </filterchain>
+              </reflexive>
+            </then>
+          </if>
+
           <echo msg="------------------------------------" />
         </then>
         <else>
-          <echo msg="N/A: skipping WP headers in project.basedir." />
+          <echo msg="N/A: skipping WP header replacements." />
 
           <echo msg="------------------------------------" />
         </else>
@@ -114,11 +129,25 @@
 
                 <regexp pattern="'[^']*?';\s*\/\/wp\-up\-to\-version\/\/$" replace="'${project_wp_tested_up_to_version}'; //wp-up-to-version//" modifiers="um" />
                 <regexp pattern='"[^"]*?";\s*\/\/wp\-up\-to\-version\/\/$' replace='"${project_wp_tested_up_to_version}"; //wp-up-to-version//' modifiers="um" />
-                <if>
-                  <and>
-                    <istrue value="${_is_wp_sharks_core_theme_plugin}" />
-                  </and>
-                  <then>
+              </replaceregexp>
+            </filterchain>
+          </reflexive>
+
+          <if>
+            <and>
+              <istrue value="${_is_wp_sharks_core_theme_plugin}" />
+            </and>
+            <then>
+              <reflexive>
+                <fileset dir="${project.basedir}" casesensitive="false">
+                  <exclude pattern="**/vendor/**" />
+                  <include pattern="*.php" />
+                  <include pattern="**/*.php" />
+                  <include pattern="*.js" />
+                  <include pattern="**/*.js" />
+                </fileset>
+                <filterchain>
+                  <replaceregexp>
                     <regexp pattern="'[^']*?';\s*\/\/wp\-sharks\-core\-required\-version\/\/$" replace="'${project_wp_sharks_core_required_version}'; //wp-sharks-core-required-version//" modifiers="um" />
                     <regexp pattern='"[^"]*?";\s*\/\/wp\-sharks\-core\-required\-version\/\/$' replace='"${project_wp_sharks_core_required_version}"; //wp-sharks-core-required-version//' modifiers="um" />
 
@@ -127,16 +156,16 @@
 
                     <regexp pattern="'[^']*?';\s*\/\/wp\-sharks\-core\-max\-compatible\-version\/\/$" replace="'${project_wp_sharks_core_max_compatible_version}'; //wp-sharks-core-max-compatible-version//" modifiers="um" />
                     <regexp pattern='"[^"]*?";\s*\/\/wp\-sharks\-core\-max\-compatible\-version\/\/$' replace='"${project_wp_sharks_core_max_compatible_version}"; //wp-sharks-core-max-compatible-version//' modifiers="um" />
-                  </then>
-                </if>
-              </replaceregexp>
-            </filterchain>
-          </reflexive>
+                  </replaceregexp>
+                </filterchain>
+              </reflexive>
+            </then>
+          </if>
 
           <echo msg="------------------------------------" />
         </then>
         <else>
-          <echo msg="N/A: skipping WP tokens in project.basedir." />
+          <echo msg="N/A: skipping WP token replacements." />
 
           <echo msg="------------------------------------" />
         </else>

--- a/src/psr4/targets/validate.xml
+++ b/src/psr4/targets/validate.xml
@@ -10,8 +10,7 @@
       <fail unless="project_title" message="Missing `project_title` in properties file!" />
       <fail unless="project_owner" message="Missing `project_owner` in properties file!" />
       <fail unless="project_slug" message="Missing `project_slug` in properties file!" />
-
-      <fail unless="project-text-domain" message="Unable to construct `project-text-domain` from `project_slug`." />
+      <fail unless="_project_text_domain" message="Failed to generate `_project_text_domain`." />
 
       <fail unless="project_namespace" message="Missing `project_namespace` in properties file!" />
       <fail unless="project_sub_namespace" message="Missing `project_sub_namespace` in properties file!" />

--- a/src/psr4/targets/validate.xml
+++ b/src/psr4/targets/validate.xml
@@ -17,28 +17,11 @@
       <fail unless="project_sub_namespace" message="Missing `project_sub_namespace` in properties file!" />
 
       <if>
-        <not>
-          <isset property="project_other_phar_fileset_exclusions" />
-        </not>
-        <then>
-          <property name="project_other_phar_fileset_exclusions" value="" />
-        </then>
-      </if>
-      <if>
-        <not>
-          <isset property="project_other_zip_tgz_fileset_exclusions" />
-        </not>
-        <then>
-          <property name="project_other_zip_tgz_fileset_exclusions" value="" />
-        </then>
-      </if>
-
-      <if>
         <and>
           <not>
-            <isset property="is_lite" />
+            <isset property="is_lite_build" />
           </not>
-          <istrue value="${_is_lite_applicable}" />
+          <istrue value="${_has_lite_build_props}" />
         </and>
         <then>
           <fail unless="project_lite_title" message="Missing `project_lite_title` in properties file!" />
@@ -46,39 +29,6 @@
 
           <fail unless="project_lite_namespace" message="Missing `project_lite_namespace` in properties file!" />
           <fail unless="project_lite_sub_namespace" message="Missing `project_lite_sub_namespace` in properties file!" />
-
-          <if>
-            <not>
-              <isset property="project_lite_other_phar_fileset_exclusions" />
-            </not>
-            <then>
-              <property name="project_lite_other_phar_fileset_exclusions" value="" />
-            </then>
-          </if>
-          <if>
-            <not>
-              <isset property="project_lite_other_zip_tgz_fileset_exclusions" />
-            </not>
-            <then>
-              <property name="project_lite_other_zip_tgz_fileset_exclusions" value="" />
-            </then>
-          </if>
-          <if>
-            <not>
-              <isset property="project_lite_text_domain_regex_replacement_pattern" />
-            </not>
-            <then>
-              <property name="project_lite_text_domain_regex_replacement_pattern" value="" />
-            </then>
-          </if>
-          <if>
-            <not>
-              <isset property="project_lite_alter_namespace_in_other_files_pattern" />
-            </not>
-            <then>
-              <property name="project_lite_alter_namespace_in_other_files_pattern" value="" />
-            </then>
-          </if>
         </then>
       </if>
 
@@ -101,14 +51,6 @@
             <then>
               <fail unless="project_wp_sharks_core_required_version" message="Missing `project_wp_sharks_core_required_version` in properties file!" />
               <fail unless="project_wp_sharks_core_tested_up_to_version" message="Missing `project_wp_sharks_core_tested_up_to_version` in properties file!" />
-              <if>
-                <not>
-                  <isset property="project_wp_sharks_core_max_compatible_version" />
-                </not>
-                <then>
-                  <property name="project_wp_sharks_core_max_compatible_version" value="" />
-                </then>
-              </if>
             </then>
           </if>
         </then>

--- a/src/psr4/targets/validate.xml
+++ b/src/psr4/targets/validate.xml
@@ -11,6 +11,8 @@
       <fail unless="project_owner" message="Missing `project_owner` in properties file!" />
       <fail unless="project_slug" message="Missing `project_slug` in properties file!" />
 
+      <fail unless="project-text-domain" message="Unable to construct `project-text-domain` from `project_slug`." />
+
       <fail unless="project_namespace" message="Missing `project_namespace` in properties file!" />
       <fail unless="project_sub_namespace" message="Missing `project_sub_namespace` in properties file!" />
 
@@ -42,6 +44,16 @@
         <then>
           <fail unless="project_wp_required_version" message="Missing `project_wp_required_version` in properties file!" />
           <fail unless="project_wp_tested_up_to_version" message="Missing `project_wp_tested_up_to_version` in properties file!" />
+          <if>
+            <and>
+              <istrue value="${_is_wp_sharks_core_theme_plugin}" />
+            </and>
+            <then>
+              <fail unless="project_wp_sharks_core_required_version" message="Missing `project_wp_sharks_core_required_version` in properties file!" />
+              <fail unless="project_wp_sharks_core_tested_up_to_version" message="Missing `project_wp_sharks_core_tested_up_to_version` in properties file!" />
+              <fail unless="project_wp_sharks_core_max_compatible_version" message="Missing `project_wp_sharks_core_max_compatible_version` in properties file!" />
+            </then>
+          </if>
         </then>
       </if>
 

--- a/src/psr4/targets/validate.xml
+++ b/src/psr4/targets/validate.xml
@@ -10,10 +10,28 @@
       <fail unless="project_title" message="Missing `project_title` in properties file!" />
       <fail unless="project_owner" message="Missing `project_owner` in properties file!" />
       <fail unless="project_slug" message="Missing `project_slug` in properties file!" />
+
       <fail unless="_project_text_domain" message="Failed to generate `_project_text_domain`." />
 
       <fail unless="project_namespace" message="Missing `project_namespace` in properties file!" />
       <fail unless="project_sub_namespace" message="Missing `project_sub_namespace` in properties file!" />
+
+      <if>
+        <not>
+          <isset property="project_other_phar_fileset_exclusions" />
+        </not>
+        <then>
+          <property name="project_other_phar_fileset_exclusions" value="" />
+        </then>
+      </if>
+      <if>
+        <not>
+          <isset property="project_other_zip_tgz_fileset_exclusions" />
+        </not>
+        <then>
+          <property name="project_other_zip_tgz_fileset_exclusions" value="" />
+        </then>
+      </if>
 
       <if>
         <and>
@@ -28,6 +46,39 @@
 
           <fail unless="project_lite_namespace" message="Missing `project_lite_namespace` in properties file!" />
           <fail unless="project_lite_sub_namespace" message="Missing `project_lite_sub_namespace` in properties file!" />
+
+          <if>
+            <not>
+              <isset property="project_lite_other_phar_fileset_exclusions" />
+            </not>
+            <then>
+              <property name="project_lite_other_phar_fileset_exclusions" value="" />
+            </then>
+          </if>
+          <if>
+            <not>
+              <isset property="project_lite_other_zip_tgz_fileset_exclusions" />
+            </not>
+            <then>
+              <property name="project_lite_other_zip_tgz_fileset_exclusions" value="" />
+            </then>
+          </if>
+          <if>
+            <not>
+              <isset property="project_lite_text_domain_regex_replacement_pattern" />
+            </not>
+            <then>
+              <property name="project_lite_text_domain_regex_replacement_pattern" value="" />
+            </then>
+          </if>
+          <if>
+            <not>
+              <isset property="project_lite_alter_namespace_in_other_files_pattern" />
+            </not>
+            <then>
+              <property name="project_lite_alter_namespace_in_other_files_pattern" value="" />
+            </then>
+          </if>
         </then>
       </if>
 
@@ -50,7 +101,14 @@
             <then>
               <fail unless="project_wp_sharks_core_required_version" message="Missing `project_wp_sharks_core_required_version` in properties file!" />
               <fail unless="project_wp_sharks_core_tested_up_to_version" message="Missing `project_wp_sharks_core_tested_up_to_version` in properties file!" />
-              <fail unless="project_wp_sharks_core_max_compatible_version" message="Missing `project_wp_sharks_core_max_compatible_version` in properties file!" />
+              <if>
+                <not>
+                  <isset property="project_wp_sharks_core_max_compatible_version" />
+                </not>
+                <then>
+                  <property name="project_wp_sharks_core_max_compatible_version" value="" />
+                </then>
+              </if>
             </then>
           </if>
         </then>


### PR DESCRIPTION
## Summary of Changes
- Modified the default build target (i.e., running just `phing` or `phing build`). This now excludes token replacements, POT generation, and it leaves an existing `composer.lock` intact. This is intended for contributors so that they can rebuild easily to test their changes. Referencing: https://github.com/websharks/phings/issues/49
- Adding a new build target `phing build-all`, which will do what `phing` and/or `phing build` did in the previous version of our PSR build process; i.e., it will perform a full/complete build that runs all targets—intended for a lead developer.
- Fixed a bug in POT generation. The `translations` directory should be created automatically if it does not yet exist.
- Fixed a bug in the `-config` and `-validate` targets. Undefined properties within Phing are interpreted as string literals instead of as empty strings, which is what we had assumed in code. For instance, if `${project_other_phar_fileset_exclusions}` (an optional property) is not defined, it was being read as the string literal `${project_other_phar_fileset_exclusions}`, which can lead to unexpected consequences. This has been fixed by running a deeper config setup and validation, and then defaulting these properties to empty strings when they are not already defined.
- Added a new internal build property: `${_project_text_domain}`, which is derived from `${project_slug}` for both the lite and pro versions. This property value will always strip away any `-lite` or `-pro` suffix, leaving us with a clean and consistent text domain for internal use.
- Renamed the internal build property `${is_lite}` to `${is_lite_build}`.
- Renamed the internal build property `${_is_lite_applicable}` to `${_has_lite_build_props}`.
- Added a new reflexive sub-routine to the `-pots` target. Any instances of `__()`, `_x()`, `_n()`, or `_nx()` that do not already include a text-domain (either as a static value or with a variable), are forced to a static value matching the plugin's text-domain. This allows a developer to build a plugin without needing to type the text-domain over and over again. It will be added automatically each time you run `phing build-all`. I expect this to become a common practice in new projects based on the WP Sharks Core in the future, as I am not planning to use variables or constants for the text-domain moving forward; i.e., this will improve translation compatibility across-the-board by doing it this way.
  
  _Note: If you have i18n calls that already specify a text-domain argument (either as a static value or as a variable, constant, etc.) those are left as-is. Also note that this does not interfere with the existing lite generation target where we absolutely force all static text-domain values whenever `${project_lite_text_domain_regex_replacement_pattern}` is defined with a regex pattern._
- New internal build property/conditional with name: `${_is_wp_sharks_core_theme_plugin}`. This is only true if WP Sharks Core properties (seen below) exist in your `.build.props` file, and only when `${_is_wp_theme_plugin}` is also true, which is an existing internal flag that we already had.
- **Adding new (optional) build properties:**
  
  Defining any of these puts the build process into 'WP Sharks Core' theme/plugin mode.
  
  ``` text
  project_wp_sharks_core_required_version = 160229
  project_wp_sharks_core_tested_up_to_version = 160229
  project_wp_sharks_core_max_compatible_version  =
  ```
  - `project_wp_sharks_core_required_version` = Required version of the WP Sharks Core.
  - `project_wp_sharks_core_tested_up_to_version` = Last tested version of the WP Sharks Core.
  - `project_wp_sharks_core_max_compatible_version` = If this is defined, it can be used by the WP Sharks Core RV handler in order to prevent the plugin from loading if a newer core framework plugin is running on any given site.
    
    _In this scenario, the site owner is shown a notice that informs them the plugin they are running is not yet compatible with the newer version of the WP Sharks Core they have, and suggests that they downgrade the WP Sharks Core or remove the old plugin._
    
    _This is going to be rarely used (because we will try hard not to have BC breaks), but it gives us a graceful way to discontinue old plugins and prevent them from loading when/if the WP Sharks Core diverges in such a way that old plugins (those not worth updating) become unusable in newer versions of the WP Sharks Core._
    
    _At the same time, it offers site owners a way to continue to use the older plugin if they want to, by providing them with instructions that explain how to downgrade the WP Sharks Core framework plugin to an older/compatible version if they want to run the older plugin._
- Added support for docBlock-style WP plugin headers as seen in the second example here: https://codex.wordpress.org/File_Header ~ I expect this to become a common practice in WP Sharks Core plugin projects.
- Improved logic and display in the `-preamble` build target.
- Bug fix. Only apply static text-domain replacements during lite generation if `${project_lite_text_domain_regex_replacement_pattern}` is defined and not empty.
