### PR TITLE
Fix bug where WP Header replacement fails for ${project_lite_slug}.php

### DIFF
--- a/src/psr4/targets/variations/lite/prepare.xml
+++ b/src/psr4/targets/variations/lite/prepare.xml
@@ -86,6 +86,7 @@
               <reflexive>
                 <fileSet dir="${project.basedir}/.~build/${project_lite_slug}" caseSensitive="false">
                   <patternSet refId="_wp_token_pattern_set" />
+                  <include pattern="${project_lite_slug}.php" />
                 </fileSet>
                 <filterChain>
                   <replaceRegExp>


### PR DESCRIPTION
See websharks/phings#95
